### PR TITLE
Update visible rows when rows prop updates

### DIFF
--- a/src/vue-datatable.vue
+++ b/src/vue-datatable.vue
@@ -75,6 +75,11 @@ module.exports = {
 		sort_by: null,
 		sort_dir: null,
 	}},
+	watch: {
+		rows: function(val){
+			this.updateRows(val);
+		}
+	},
 	computed: {
 		column_props: function(){
 			var i = 0;


### PR DESCRIPTION
Makes this component work when using AJAX to fetch data from the server. Currently, any updates to the rows has no effect on `visible_rows`.