### PR TITLE
Don't mix imports and module.exports due to babel plugin updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
-import VueDatatable from './src/vue-datatable.vue'
-module.exports = VueDatatable
+import VueDatatable from './src/vue-datatable.vue';
+
+export default VueDatatable;

--- a/src/filter-bar.vue
+++ b/src/filter-bar.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
 	props: {
 		columns: [Object, Array],
 		rows: [Object, Array],

--- a/src/vue-datatable.vue
+++ b/src/vue-datatable.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
 	props: {
 		columns: [Object, Array],
 		rows: [Object, Array],


### PR DESCRIPTION
Some babel plugins have started throwing errors if you use both `import` and `module.exports`. You're using import statements so I just changed it to be consistent and use `export default`.