### PR TITLE
Fix build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A Vue.js component for filterable, sortable, and paginated tables.",
   "main": "index.js",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack --progress --hide-modules",
-    "watch": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules",
-    "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot",
-    "production": "cross-env NODE_ENV=production webpack --progress --hide-modules"
+    "dev": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules",
+    "watch": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules",
+    "hot": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot ",
+    "production": "node node_modules/cross-env/bin/cross-env.js NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules"
   },
   "keywords": [
     "Vue.js",


### PR DESCRIPTION
I think old scripts must install `cross-env` and `webpack` to global.
Because I installed packages and run `npm run production` then get `cross-env: command not found`

```shell
✝ ~/Develop/PR/vue-datatable  fix-build-scripts±  yarn install --pure-lockfile
yarn install v0.20.0
info No lockfile found.
[1/4] 🔍  Resolving packages...
warning laravel-mix > browser-sync > localtunnel > request > node-uuid@1.4.7: use uuid module instead
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
warning Your current version of Yarn is out of date. The latest version is "0.21.3" while you're on "0.20.0".
info To upgrade, run the following command:
$ curl -o- -L https://yarnpkg.com/install.sh | bash
✨  Done in 23.54s.
 ✝ ~/Develop/PR/vue-datatable  fix-build-scripts±  npm run production

> vuejs-datatable@0.9.0 production /Users/casperlai/Develop/PR/vue-datatable
> cross-env NODE_ENV=production webpack --progress --hide-modules

sh: cross-env: command not found
```

So I think we can use local packages for build scripts