### PR TITLE
Fix lifecycle, make component usable in ES5

### DIFF
--- a/src/stores/json.js
+++ b/src/stores/json.js
@@ -1,19 +1,21 @@
 import objectPath from 'object-path';
 
 export default {
-	data: () => ({
-		paginate: false,
-		filterable: false,
-		sortable: false,
-		can_resize: true,
-		filter: '',
-		sort_by: '',
-		sort_dir: 'asc',
-		page: 1,
-		page_size: 10,
-		data: [],
-		table: null
-	}),
+	data() { 
+		return {
+			paginate: false,
+			filterable: false,
+			sortable: false,
+			can_resize: true,
+			filter: '',
+			sort_by: '',
+			sort_dir: 'asc',
+			page: 1,
+			page_size: 10,
+			data: [],
+			table: null
+		}
+	},
 	computed: {
 		last_page(){
 			return Math.ceil(this.filtered_rows.length / this.page_size);

--- a/src/vue-datatable.vue
+++ b/src/vue-datatable.vue
@@ -85,6 +85,7 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import objectPath from 'object-path';
 import json_store from './stores/json.js';
 
@@ -109,9 +110,11 @@ export default {
 			default: null
 		}
 	},
-	data: () => ({
-		store: null
-	}),
+	data() { 
+		return {
+			store: null
+		}
+	},
 	computed: {
 		column_props: function(){
 			var i = 0;
@@ -150,6 +153,17 @@ export default {
 			return is_array && can_resize;
 		}
 	},
+	beforeMount() {
+		if (this.dataStore) {
+			this.store = new Vue(this.dataStore);
+		} else {
+			this.store = new Vue(json_store);
+		}
+		this.updateStore(this.data);
+	},
+	beforeDestroy() {
+		this.store.$destroy(); // Necessary because store is not a component
+	},
 	methods: {
 		getHeaderColumnClass(head_column){
 			const can_sort = this.store.sortable;
@@ -172,12 +186,6 @@ export default {
 			}
 		},
 		updateStore(data){
-			if(this.dataStore){
-				this.store = new Vue(this.dataStore);
-			}else{
-				this.store = new Vue(json_store);
-			}
-
 			this.store.setTable(this);
 			this.store.setData(data);
 			this.store.setFilterable(this.filterable);
@@ -187,9 +195,6 @@ export default {
 		getRowFromField(row, field) {
 		    return objectPath.get(row, field)
 		}
-	},
-	created(){
-		this.updateStore(this.data);
 	},
 	watch: {
 		data(){


### PR DESCRIPTION
* Fix missing Vue import. #11
* With the store being recreated on every data update, weird issues result (including the filter/column sort being reset on every data update and the potential for memory leaks). Instead, create the store once on beforeMount (not create, as that's only called once per application) and cleanup in beforeDestroy. This fixes filter/column sort behavior when data is updated.
* This also fixes using multiple datatables in a single root component (due to the aforementioned problems with creating the store on create).
* Remove arrow functions, otherwise it's not usable in ES5 environments.