### PR TITLE
Added Bootstrap 4 classes to pager buttons

### DIFF
--- a/src/vue-datatable-pager-button.vue
+++ b/src/vue-datatable-pager-button.vue
@@ -28,7 +28,7 @@ export default {
 	},
 	computed: {
 		li_classes(){
-			var classes = [];
+			var classes = ['page-item'];
 
 			if(this.settings.get('pager.classes.li')){
 				classes.push(this.settings.get('pager.classes.li'));
@@ -45,7 +45,7 @@ export default {
 			return classes.join(' ');
 		},
 		a_classes(){
-			var classes = [];
+			var classes = ['page-link'];
 
 			if(this.settings.get('pager.classes.a')){
 				classes.push(this.settings.get('pager.classes.a'));


### PR DESCRIPTION
Currently, the pagination buttons are not styled properly in Bootstrap 4, since new classes were added:
https://getbootstrap.com/docs/4.0/components/pagination/

I added these classes by default and tested the new build locally, and now Bootstrap 4 styling is respected by default.  This should be backward-compatible with Bootstrap 3 since these classes will simply be ignored.

This is my first time contributing to a Vue-based project.  Please let me know if there is anything else I need to provide for this to be useful.  :)